### PR TITLE
Add Tabs for HTML, Next.js, and Astro Metadata Generators

### DIFF
--- a/app/_components/generate-tags/generate-tags-modal.tsx
+++ b/app/_components/generate-tags/generate-tags-modal.tsx
@@ -1,3 +1,191 @@
+// import { CopyButton } from "@/components/copy-button";
+// import { Alert, AlertDescription } from "@/components/ui/alert";
+// import { Button } from "@/components/ui/button";
+// import {
+//   Dialog,
+//   DialogClose,
+//   DialogContent,
+//   DialogDescription,
+//   DialogHeader,
+//   DialogTitle,
+//   DialogTrigger,
+// } from "@/components/ui/dialog";
+// import { Label } from "@/components/ui/label";
+// import { getMetaTagsCode } from "@/lib/get-meta-tags";
+// import { useMetaTagsStore } from "@/store/use-meta-tags-store";
+// import { useSeoFormStore } from "@/store/use-seo-form-store";
+// import { AlertOctagonIcon, TagIcon, XIcon } from "lucide-react";
+// import Link from "next/link";
+// import React from "react";
+// import { ComponentSource } from "../meta-tags-source";
+
+// export default function GenerateTagsModal({ children }: { children: React.ReactNode }) {
+//   const { code } = useMetaTagsStore();
+//   const { title, description, url, imageFile } = useSeoFormStore();
+
+//   return (
+//     <Dialog>
+//       <DialogTrigger asChild>{children}</DialogTrigger>
+//       <DialogContent className="flex flex-col gap-0 p-0 sm:max-h-[min(640px,80vh)] sm:max-w-lg md:max-w-3xl lg:max-w-5xl [&>button:last-child]:hidden">
+//         <DialogHeader className="contents space-y-0 text-left">
+//           <DialogTitle className="flex items-center justify-between px-6 pt-6">
+//             <div className="flex items-center gap-2">
+//               <TagIcon className="text-blue-500" />
+//               <p>Generated Meta Tags</p>
+//             </div>
+//             <DialogClose asChild>
+//               <Button variant={"ghost"} size={"icon"}>
+//                 <XIcon />
+//               </Button>
+//             </DialogClose>
+//           </DialogTitle>
+//           <DialogDescription asChild>
+//             <div className="p-4">
+//               <Alert variant={"warning"} className="mb-2">
+//                 <AlertOctagonIcon />
+//                 <AlertDescription>
+//                   <p>Please review the generated metadata, and paths before using it in production.</p>
+//                 </AlertDescription>
+//               </Alert>
+//               <ComponentSource
+//                 src={getMetaTagsCode({
+//                   title,
+//                   description,
+//                   url,
+//                   imageFile,
+//                 })}
+//               />
+//               <div className="flex items-center justify-between p-2 text-sm">
+//                 <Label>
+//                   Insert this code into your{" "}
+//                   <Link
+//                     href={"https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/head"}
+//                     target="_blank"
+//                     rel="noreferrer noopener"
+//                     className="rounded-sm bg-neutral-900 p-1 font-mono shadow-md transition-all hover:bg-neutral-800 hover:shadow-lg active:scale-95"
+//                   >
+//                     <code>&lt;head /&gt;</code>{" "}
+//                   </Link>
+//                   element.
+//                 </Label>
+//                 <CopyButton value={code} />
+//               </div>
+//             </div>
+//           </DialogDescription>
+//         </DialogHeader>
+//       </DialogContent>
+//     </Dialog>
+//   );
+// }
+
+
+// // import { CopyButton } from "@/components/copy-button";
+// // import { Alert, AlertDescription } from "@/components/ui/alert";
+// // import { Button } from "@/components/ui/button";
+// // import {
+// //   Dialog,
+// //   DialogClose,
+// //   DialogContent,
+// //   DialogDescription,
+// //   DialogHeader,
+// //   DialogTitle,
+// //   DialogTrigger,
+// // } from "@/components/ui/dialog";
+// // import { Label } from "@/components/ui/label";
+// // import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"; // new
+// // // import { getAstroMetadataCode } from "@/lib/get-astro-metadata"; // new (to implement)
+// // import { getMetaTagsCode } from "@/lib/get-meta-tags";
+// // // import { getNextJsMetadataCode } from "@/lib/get-nextjs-metadata"; // new (to implement)
+// // import { useSeoFormStore } from "@/store/use-seo-form-store";
+// // import { AlertOctagonIcon, TagIcon, XIcon } from "lucide-react";
+// // import Link from "next/link";
+// // import React from "react";
+// // import { ComponentSource } from "../meta-tags-source";
+
+// // export default function GenerateTagsModal({ children }: { children: React.ReactNode }) {
+// //   const { title, description, url, imageFile } = useSeoFormStore();
+
+// //   return (
+// //     <Dialog>
+// //       <DialogTrigger asChild>{children}</DialogTrigger>
+// //       <DialogContent className="flex flex-col gap-0 p-0 sm:max-h-[min(640px,80vh)] sm:max-w-lg md:max-w-3xl lg:max-w-5xl [&>button:last-child]:hidden">
+// //         <DialogHeader className="contents space-y-0 text-left">
+// //           <DialogTitle className="flex items-center justify-between px-6 pt-6">
+// //             <div className="flex items-center gap-2">
+// //               <TagIcon className="text-blue-500" />
+// //               <p>Generated Meta Tags</p>
+// //             </div>
+// //             <DialogClose asChild>
+// //               <Button variant={"ghost"} size={"icon"}>
+// //                 <XIcon />
+// //               </Button>
+// //             </DialogClose>
+// //           </DialogTitle>
+// //           <DialogDescription asChild>
+// //             <div className="p-4">
+// //               <Alert variant={"warning"} className="mb-2">
+// //                 <AlertOctagonIcon />
+// //                 <AlertDescription>
+// //                   <p>Please review the generated metadata, and paths before using it in production.</p>
+// //                 </AlertDescription>
+// //               </Alert>
+
+// //               {/* 🔥 New Tabs */}
+// //               <Tabs defaultValue="html">
+// //                 <TabsList>
+// //                   <TabsTrigger value="html">HTML</TabsTrigger>
+// //                   <TabsTrigger value="nextjs">Next.js</TabsTrigger>
+// //                   <TabsTrigger value="astro">Astro</TabsTrigger>
+// //                 </TabsList>
+
+// //                 {/* HTML */}
+// //                 <TabsContent value="html">
+// //                   <ComponentSource
+// //                     src={getMetaTagsCode({ title, description, url, imageFile })}
+// //                   />
+// //                   <CopyButton value={getMetaTagsCode({ title, description, url, imageFile })} />
+// //                 </TabsContent>
+
+// //                 {/* Next.js */}
+// //                 {/* <TabsContent value="nextjs">
+// //                   <ComponentSource
+// //                     src={getNextJsMetadataCode({ title, description, url, imageFile })}
+// //                   />
+// //                   <CopyButton value={getNextJsMetadataCode({ title, description, url, imageFile })} />
+// //                 </TabsContent> */}
+
+// //                 {/* Astro */}
+// //                 {/* <TabsContent value="astro">
+// //                   <ComponentSource
+// //                     src={getAstroMetadataCode({ title, description, url, imageFile })}
+// //                   />
+// //                   <CopyButton value={getAstroMetadataCode({ title, description, url, imageFile })} />
+// //                 </TabsContent> */}
+// //               </Tabs>
+
+// //               <div className="flex items-center justify-between p-2 text-sm">
+// //                 <Label>
+// //                   Insert this code into your{" "}
+// //                   <Link
+// //                     href={"https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/head"}
+// //                     target="_blank"
+// //                     rel="noreferrer noopener"
+// //                     className="rounded-sm bg-neutral-900 p-1 font-mono shadow-md transition-all hover:bg-neutral-800 hover:shadow-lg active:scale-95"
+// //                   >
+// //                     <code>&lt;head /&gt;</code>{" "}
+// //                   </Link>
+// //                   element.
+// //                 </Label>
+// //               </div>
+// //             </div>
+// //           </DialogDescription>
+// //         </DialogHeader>
+// //       </DialogContent>
+// //     </Dialog>
+// //   );
+// // }
+
+
 import { CopyButton } from "@/components/copy-button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -11,8 +199,10 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"; // 👈 new
+import { getAstroMetadataCode } from "@/lib/get-astro-metadata"; // 👈 new
 import { getMetaTagsCode } from "@/lib/get-meta-tags";
-import { useMetaTagsStore } from "@/store/use-meta-tags-store";
+import { getNextJsMetadataCode } from "@/lib/get-nextjs-metadata"; // 👈 new
 import { useSeoFormStore } from "@/store/use-seo-form-store";
 import { AlertOctagonIcon, TagIcon, XIcon } from "lucide-react";
 import Link from "next/link";
@@ -20,8 +210,12 @@ import React from "react";
 import { ComponentSource } from "../meta-tags-source";
 
 export default function GenerateTagsModal({ children }: { children: React.ReactNode }) {
-  const { code } = useMetaTagsStore();
   const { title, description, url, imageFile } = useSeoFormStore();
+
+  // pre-generate all codes
+  const htmlCode = getMetaTagsCode({ title, description, url, imageFile });
+  const nextCode = getNextJsMetadataCode({ title, description, url, imageFile });
+  const astroCode = getAstroMetadataCode({ title, description, url, imageFile });
 
   return (
     <Dialog>
@@ -34,42 +228,64 @@ export default function GenerateTagsModal({ children }: { children: React.ReactN
               <p>Generated Meta Tags</p>
             </div>
             <DialogClose asChild>
-              <Button variant={"ghost"} size={"icon"}>
+              <Button variant="ghost" size="icon">
                 <XIcon />
               </Button>
             </DialogClose>
           </DialogTitle>
           <DialogDescription asChild>
             <div className="p-4">
-              <Alert variant={"warning"} className="mb-2">
+              <Alert variant="warning" className="mb-2">
                 <AlertOctagonIcon />
                 <AlertDescription>
-                  <p>Please review the generated metadata, and paths before using it in production.</p>
+                  <p>
+                    Please review the generated metadata, and paths before using it in
+                    production.
+                  </p>
                 </AlertDescription>
               </Alert>
-              <ComponentSource
-                src={getMetaTagsCode({
-                  title,
-                  description,
-                  url,
-                  imageFile,
-                })}
-              />
-              <div className="flex items-center justify-between p-2 text-sm">
-                <Label>
-                  Insert this code into your{" "}
-                  <Link
-                    href={"https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/head"}
-                    target="_blank"
-                    rel="noreferrer noopener"
-                    className="rounded-sm bg-neutral-900 p-1 font-mono shadow-md transition-all hover:bg-neutral-800 hover:shadow-lg active:scale-95"
-                  >
-                    <code>&lt;head /&gt;</code>{" "}
-                  </Link>
-                  element.
-                </Label>
-                <CopyButton value={code} />
-              </div>
+
+              {/* Tabs wrapper */}
+              <Tabs defaultValue="html">
+                <TabsList>
+                  <TabsTrigger value="html">HTML</TabsTrigger>
+                  <TabsTrigger value="next">Next.js</TabsTrigger>
+                  <TabsTrigger value="astro">Astro</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="html">
+                  <ComponentSource src={htmlCode} />
+                  <div className="flex items-center justify-between p-2 text-sm">
+                    <Label>
+                      Insert this code into your{" "}
+                      <Link
+                        href="https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/head"
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="rounded-sm bg-neutral-900 p-1 font-mono shadow-md transition-all hover:bg-neutral-800 hover:shadow-lg active:scale-95"
+                      >
+                        <code>&lt;head /&gt;</code>
+                      </Link>{" "}
+                      element.
+                    </Label>
+                    <CopyButton value={htmlCode} />
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="next">
+                  <ComponentSource src={nextCode} />
+                  <div className="flex justify-end p-2 text-sm">
+                    <CopyButton value={nextCode} />
+                  </div>
+                </TabsContent>
+
+                <TabsContent value="astro">
+                  <ComponentSource src={astroCode} />
+                  <div className="flex justify-end p-2 text-sm">
+                    <CopyButton value={astroCode} />
+                  </div>
+                </TabsContent>
+              </Tabs>
             </div>
           </DialogDescription>
         </DialogHeader>

--- a/app/_components/generate-tags/generate-tags-modal.tsx
+++ b/app/_components/generate-tags/generate-tags-modal.tsx
@@ -1,191 +1,3 @@
-// import { CopyButton } from "@/components/copy-button";
-// import { Alert, AlertDescription } from "@/components/ui/alert";
-// import { Button } from "@/components/ui/button";
-// import {
-//   Dialog,
-//   DialogClose,
-//   DialogContent,
-//   DialogDescription,
-//   DialogHeader,
-//   DialogTitle,
-//   DialogTrigger,
-// } from "@/components/ui/dialog";
-// import { Label } from "@/components/ui/label";
-// import { getMetaTagsCode } from "@/lib/get-meta-tags";
-// import { useMetaTagsStore } from "@/store/use-meta-tags-store";
-// import { useSeoFormStore } from "@/store/use-seo-form-store";
-// import { AlertOctagonIcon, TagIcon, XIcon } from "lucide-react";
-// import Link from "next/link";
-// import React from "react";
-// import { ComponentSource } from "../meta-tags-source";
-
-// export default function GenerateTagsModal({ children }: { children: React.ReactNode }) {
-//   const { code } = useMetaTagsStore();
-//   const { title, description, url, imageFile } = useSeoFormStore();
-
-//   return (
-//     <Dialog>
-//       <DialogTrigger asChild>{children}</DialogTrigger>
-//       <DialogContent className="flex flex-col gap-0 p-0 sm:max-h-[min(640px,80vh)] sm:max-w-lg md:max-w-3xl lg:max-w-5xl [&>button:last-child]:hidden">
-//         <DialogHeader className="contents space-y-0 text-left">
-//           <DialogTitle className="flex items-center justify-between px-6 pt-6">
-//             <div className="flex items-center gap-2">
-//               <TagIcon className="text-blue-500" />
-//               <p>Generated Meta Tags</p>
-//             </div>
-//             <DialogClose asChild>
-//               <Button variant={"ghost"} size={"icon"}>
-//                 <XIcon />
-//               </Button>
-//             </DialogClose>
-//           </DialogTitle>
-//           <DialogDescription asChild>
-//             <div className="p-4">
-//               <Alert variant={"warning"} className="mb-2">
-//                 <AlertOctagonIcon />
-//                 <AlertDescription>
-//                   <p>Please review the generated metadata, and paths before using it in production.</p>
-//                 </AlertDescription>
-//               </Alert>
-//               <ComponentSource
-//                 src={getMetaTagsCode({
-//                   title,
-//                   description,
-//                   url,
-//                   imageFile,
-//                 })}
-//               />
-//               <div className="flex items-center justify-between p-2 text-sm">
-//                 <Label>
-//                   Insert this code into your{" "}
-//                   <Link
-//                     href={"https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/head"}
-//                     target="_blank"
-//                     rel="noreferrer noopener"
-//                     className="rounded-sm bg-neutral-900 p-1 font-mono shadow-md transition-all hover:bg-neutral-800 hover:shadow-lg active:scale-95"
-//                   >
-//                     <code>&lt;head /&gt;</code>{" "}
-//                   </Link>
-//                   element.
-//                 </Label>
-//                 <CopyButton value={code} />
-//               </div>
-//             </div>
-//           </DialogDescription>
-//         </DialogHeader>
-//       </DialogContent>
-//     </Dialog>
-//   );
-// }
-
-
-// // import { CopyButton } from "@/components/copy-button";
-// // import { Alert, AlertDescription } from "@/components/ui/alert";
-// // import { Button } from "@/components/ui/button";
-// // import {
-// //   Dialog,
-// //   DialogClose,
-// //   DialogContent,
-// //   DialogDescription,
-// //   DialogHeader,
-// //   DialogTitle,
-// //   DialogTrigger,
-// // } from "@/components/ui/dialog";
-// // import { Label } from "@/components/ui/label";
-// // import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"; // new
-// // // import { getAstroMetadataCode } from "@/lib/get-astro-metadata"; // new (to implement)
-// // import { getMetaTagsCode } from "@/lib/get-meta-tags";
-// // // import { getNextJsMetadataCode } from "@/lib/get-nextjs-metadata"; // new (to implement)
-// // import { useSeoFormStore } from "@/store/use-seo-form-store";
-// // import { AlertOctagonIcon, TagIcon, XIcon } from "lucide-react";
-// // import Link from "next/link";
-// // import React from "react";
-// // import { ComponentSource } from "../meta-tags-source";
-
-// // export default function GenerateTagsModal({ children }: { children: React.ReactNode }) {
-// //   const { title, description, url, imageFile } = useSeoFormStore();
-
-// //   return (
-// //     <Dialog>
-// //       <DialogTrigger asChild>{children}</DialogTrigger>
-// //       <DialogContent className="flex flex-col gap-0 p-0 sm:max-h-[min(640px,80vh)] sm:max-w-lg md:max-w-3xl lg:max-w-5xl [&>button:last-child]:hidden">
-// //         <DialogHeader className="contents space-y-0 text-left">
-// //           <DialogTitle className="flex items-center justify-between px-6 pt-6">
-// //             <div className="flex items-center gap-2">
-// //               <TagIcon className="text-blue-500" />
-// //               <p>Generated Meta Tags</p>
-// //             </div>
-// //             <DialogClose asChild>
-// //               <Button variant={"ghost"} size={"icon"}>
-// //                 <XIcon />
-// //               </Button>
-// //             </DialogClose>
-// //           </DialogTitle>
-// //           <DialogDescription asChild>
-// //             <div className="p-4">
-// //               <Alert variant={"warning"} className="mb-2">
-// //                 <AlertOctagonIcon />
-// //                 <AlertDescription>
-// //                   <p>Please review the generated metadata, and paths before using it in production.</p>
-// //                 </AlertDescription>
-// //               </Alert>
-
-// //               {/* 🔥 New Tabs */}
-// //               <Tabs defaultValue="html">
-// //                 <TabsList>
-// //                   <TabsTrigger value="html">HTML</TabsTrigger>
-// //                   <TabsTrigger value="nextjs">Next.js</TabsTrigger>
-// //                   <TabsTrigger value="astro">Astro</TabsTrigger>
-// //                 </TabsList>
-
-// //                 {/* HTML */}
-// //                 <TabsContent value="html">
-// //                   <ComponentSource
-// //                     src={getMetaTagsCode({ title, description, url, imageFile })}
-// //                   />
-// //                   <CopyButton value={getMetaTagsCode({ title, description, url, imageFile })} />
-// //                 </TabsContent>
-
-// //                 {/* Next.js */}
-// //                 {/* <TabsContent value="nextjs">
-// //                   <ComponentSource
-// //                     src={getNextJsMetadataCode({ title, description, url, imageFile })}
-// //                   />
-// //                   <CopyButton value={getNextJsMetadataCode({ title, description, url, imageFile })} />
-// //                 </TabsContent> */}
-
-// //                 {/* Astro */}
-// //                 {/* <TabsContent value="astro">
-// //                   <ComponentSource
-// //                     src={getAstroMetadataCode({ title, description, url, imageFile })}
-// //                   />
-// //                   <CopyButton value={getAstroMetadataCode({ title, description, url, imageFile })} />
-// //                 </TabsContent> */}
-// //               </Tabs>
-
-// //               <div className="flex items-center justify-between p-2 text-sm">
-// //                 <Label>
-// //                   Insert this code into your{" "}
-// //                   <Link
-// //                     href={"https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/head"}
-// //                     target="_blank"
-// //                     rel="noreferrer noopener"
-// //                     className="rounded-sm bg-neutral-900 p-1 font-mono shadow-md transition-all hover:bg-neutral-800 hover:shadow-lg active:scale-95"
-// //                   >
-// //                     <code>&lt;head /&gt;</code>{" "}
-// //                   </Link>
-// //                   element.
-// //                 </Label>
-// //               </div>
-// //             </div>
-// //           </DialogDescription>
-// //         </DialogHeader>
-// //       </DialogContent>
-// //     </Dialog>
-// //   );
-// // }
-
-
 import { CopyButton } from "@/components/copy-button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -199,10 +11,10 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"; // 👈 new
-import { getAstroMetadataCode } from "@/lib/get-astro-metadata"; // 👈 new
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { getAstroMetadataCode } from "@/lib/get-astro-metadata";
 import { getMetaTagsCode } from "@/lib/get-meta-tags";
-import { getNextJsMetadataCode } from "@/lib/get-nextjs-metadata"; // 👈 new
+import { getNextJsMetadataCode } from "@/lib/get-nextjs-metadata";
 import { useSeoFormStore } from "@/store/use-seo-form-store";
 import { AlertOctagonIcon, TagIcon, XIcon } from "lucide-react";
 import Link from "next/link";
@@ -212,7 +24,6 @@ import { ComponentSource } from "../meta-tags-source";
 export default function GenerateTagsModal({ children }: { children: React.ReactNode }) {
   const { title, description, url, imageFile } = useSeoFormStore();
 
-  // pre-generate all codes
   const htmlCode = getMetaTagsCode({ title, description, url, imageFile });
   const nextCode = getNextJsMetadataCode({ title, description, url, imageFile });
   const astroCode = getAstroMetadataCode({ title, description, url, imageFile });
@@ -238,10 +49,7 @@ export default function GenerateTagsModal({ children }: { children: React.ReactN
               <Alert variant="warning" className="mb-2">
                 <AlertOctagonIcon />
                 <AlertDescription>
-                  <p>
-                    Please review the generated metadata, and paths before using it in
-                    production.
-                  </p>
+                  <p>Please review the generated metadata, and paths before using it in production.</p>
                 </AlertDescription>
               </Alert>
 

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -7,14 +7,14 @@ import * as React from "react";
 const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.List
     ref={ref}
     className={cn(
       "inline-flex h-10 items-center justify-center rounded-md bg-neutral-100 p-1 dark:bg-neutral-800",
-      className
+      className,
     )}
     {...props}
   />
@@ -22,14 +22,14 @@ const TabsList = React.forwardRef<
 TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white dark:data-[state=active]:bg-neutral-700 shadow-sm",
-      className
+      "ring-offset-background focus-visible:ring-ring inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium shadow-sm transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white dark:data-[state=active]:bg-neutral-700",
+      className,
     )}
     {...props}
   />
@@ -37,15 +37,12 @@ const TabsTrigger = React.forwardRef<
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
 >(({ className, ...props }, ref) => (
   <TabsPrimitive.Content
     ref={ref}
-    className={cn(
-      "mt-2 rounded-md border border-neutral-200 p-4 dark:border-neutral-700",
-      className
-    )}
+    className={cn("mt-2 rounded-md border border-neutral-200 p-4 dark:border-neutral-700", className)}
     {...props}
   />
 ));

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import * as React from "react";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-neutral-100 p-1 dark:bg-neutral-800",
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-white dark:data-[state=active]:bg-neutral-700 shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 rounded-md border border-neutral-200 p-4 dark:border-neutral-700",
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsContent, TabsList, TabsTrigger };
+

--- a/lib/get-astro-metadata.ts
+++ b/lib/get-astro-metadata.ts
@@ -1,0 +1,32 @@
+import { SeoFormState } from "@/store/use-seo-form-store";
+
+type MetaTagsProps = Omit<
+  SeoFormState,
+  "setTitle" | "setDescription" | "setImageFile" | "setUrl" | "getIsFormComplete"
+>;
+
+export function getAstroMetadataCode(props: MetaTagsProps) {
+  const imageUrl = props.imageFile ? `/${props.imageFile.file.name}` : null;
+
+  return `---
+import { defineAstroMetadata } from "astro:metadata";
+
+export const metadata = defineAstroMetadata({
+  title: "${props.title}",
+  description: "${props.description}",
+  ${props.url ? `canonical: "${props.url}",` : ""}
+  openGraph: {
+    title: "${props.title}",
+    description: "${props.description}",
+    ${props.url ? `url: "${props.url}",` : ""}
+    ${imageUrl ? `images: ["${imageUrl}"],` : ""}
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "${props.title}",
+    description: "${props.description}",
+    ${imageUrl ? `images: ["${imageUrl}"],` : ""}
+  },
+});
+---`;
+}

--- a/lib/get-nextjs-metadata.ts
+++ b/lib/get-nextjs-metadata.ts
@@ -1,0 +1,30 @@
+import { SeoFormState } from "@/store/use-seo-form-store";
+
+type MetaTagsProps = Omit<
+  SeoFormState,
+  "setTitle" | "setDescription" | "setImageFile" | "setUrl" | "getIsFormComplete"
+>;
+
+export function getNextJsMetadataCode(props: MetaTagsProps) {
+  const imageUrl = props.imageFile ? `/${props.imageFile.file.name}` : null;
+
+  return `export const metadata = {
+  title: "${props.title}",
+  description: "${props.description}",
+  openGraph: {
+    type: "website",
+    ${props.url ? `url: "${props.url}",` : ""}
+    title: "${props.title}",
+    description: "${props.description}",
+    ${imageUrl ? `images: ["${imageUrl}"],` : ""}
+    siteName: "${props.title}",
+  },
+  twitter: {
+    card: "summary_large_image",
+    ${props.url ? `url: "${props.url}",` : ""}
+    title: "${props.title}",
+    description: "${props.description}",
+    ${imageUrl ? `images: ["${imageUrl}"],` : ""}
+  },
+};`;
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@remixicon/react": "^4.6.0",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
The issue requested splitting the generated metadata output into separate formats (HTML, Next.js, and Astro) instead of rendering all in a single block. This improves readability and allows users to quickly find the metadata format they care about.

<img width="1245" height="837" alt="html" src="https://github.com/user-attachments/assets/b7223f34-c528-44c6-83f6-1ea14f5d92d9" />
<img width="1276" height="852" alt="astro" src="https://github.com/user-attachments/assets/fd7ced75-133f-4d60-b0a4-14233d882c9b" />
<img width="1266" height="776" alt="nxtjs" src="https://github.com/user-attachments/assets/6b49e1c2-5b5e-4884-ac53-077dea3e5bc2" />
